### PR TITLE
Fix: Remove incorrect statement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # kernel-checkers
-Docker image for building the Linux kernel
-
 This repository provides a suite of shell scripts designed to validate
 Linux kernel patches for correctness. These scripts can be run independently
 or collectively using the run_scripts.sh wrapper.


### PR DESCRIPTION
Remove the sentence stating that this repository is a docker image for building the kernel.