### PR TITLE
ci: Updated Docker build step to pull image from registry

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -29,22 +29,14 @@ jobs:
       labels: [self-hosted, kernel-prd-u2404-x64-large-od-ephem]
 
     steps:
-      - name: Clone kmake-image
+      - name: Pull Docker Image
         run: |
-          git clone https://github.com/qualcomm-linux/kmake-image.git
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          load: true
-          tags: kmake-image:latest
-          context: kmake-image
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          echo "Pulling Docker Image..."
+          echo "::group::$(printf '__________ %-100s' 'Pull Image' | tr ' ' _)"
+          docker pull artifacts.codelinaro.org/clo-420-qli-registry/kmake-image:ver.1.0
+          docker tag artifacts.codelinaro.org/clo-420-qli-registry/kmake-image:ver.1.0 kmake-image:latest
+          echo "::endgroup::"
+          echo "Docker Image Pulled Successfully"
 
       - name: Checkout code
         uses: qualcomm-linux/kernel-checkers/.github/actions/sync@main


### PR DESCRIPTION
# Description

Replaced the previous Docker image-building process with a direct pull from the repository. Now using: `docker pull artifacts.codelinaro.org/clo-420-qli-registry/kmake-image:ver.1.0` This enhances efficiency by leveraging pre-built images, reducing build time, and ensuring consistency across environments.