### PR TITLE
check-patch-complance: check to skip missing Link and run b4 via Docker

### DIFF
--- a/check-patch-compliance.sh
+++ b/check-patch-compliance.sh
@@ -33,43 +33,47 @@ for commit in $commits; do
   if ! echo "$commit_message" | grep -q '^Link:'; then
     echo "No 'Link' found in commit message"
     exit_status=1
-  fi
-
-  #Extract the Link URL from the commit message
-  link=$(echo "$commit_message" | grep '^Link:' | sed 's/Link:[[:space:]]*//I')
-
-  # Fetch patch using b4
-  b4 am --single-message -C -l -3 $link -o out > /dev/null 2>&1
-
-  # Check if patch was fetched successfully
-  if [ ! -d out ]; then
-    echo "Something seems wrong with the provided link. Please verify it"
-    echo "Try below command to run locally-"
-    echo "b4 am --single-message -C -l -3 $link"
-    exit_status=1
   else
-    # Extract code changes from both sources
-    grep -E '^[+-][^+-]' out/*.mbx > out/from_mbox
-    git format-patch -1 $commit --stdout | grep -E '^[+-][^+-]' > out/from_git_commit
+    #Extract the Link URL from the commit message
+    link=$(echo "$commit_message" | grep '^Link:' | sed 's/Link:[[:space:]]*//I')
 
-    # Compare the changes
-    if ! diff out/from_git_commit out/from_mbox > /dev/null; then
-      echo "Change is different from the one mentioned in Link"
-    fi
+    mkdir out
+    # Fetch patch using b4
+    run_in_kmake_image_with_passwd b4 am --single-message -C -l -3 $link -o out > /dev/null 2>&1
 
-    # Extract author from mbox downloaded
-    mbox_author=$(grep -m 1 '^From:' out/*.mbx | sed 's/^From:[[:space:]]*//')
-
-    # Extract the author from local commit
-    git_author=$(git show -s --format='%an <%ae>' $commit)
-
-    # Compare authors
-    if [ ! "$mbox_author" = "$git_author" ]; then
-      echo "Author mismatch:"
-      echo "  Original author: $mbox_author"
-      echo "  Commit author : $git_author"
+    # Check if patch was fetched successfully
+    if [ -z "$(ls -A out)" ]; then
+      echo "Something seems wrong with the provided link. Please verify it"
+      echo "Try below command to run locally-"
+      echo "b4 am --single-message -C -l -3 $link"
       exit_status=1
+    else
+      # Extract code changes from both sources
+      awk '/^diff --git /, /^--$/ { print }' out/*.mbx | grep -E '^[+-][^+-]' > out/from_mbox
+      git format-patch -1 $commit --stdout | grep -E '^[+-][^+-]' > out/from_git_commit
+
+      # Compare the changes
+      if ! diff out/from_git_commit out/from_mbox > /dev/null; then
+        echo "Change is different from the one mentioned in Link"
+	exit_status=1
+      fi
+
+      # Extract author from mbox downloaded
+      mbox_author=$(grep -m 1 '^From:' out/*.mbx | sed 's/^From:[[:space:]]*//')
+
+      # Extract the author from local commit
+      git_author=$(git show -s --format='%an <%ae>' $commit)
+
+      # Compare authors
+      if [ ! "$mbox_author" = "$git_author" ]; then
+        echo "Author mismatch:"
+        echo "  Original author: $mbox_author"
+        echo "  Commit author : $git_author"
+        exit_status=1
+      fi
     fi
+
+    rm -rf out
   fi
 
   # Check if summary starts with one of the required prefixes
@@ -79,7 +83,6 @@ for commit in $commits; do
   fi
 
   echo ""
-  rm -rf out
 done
 
 if [ "$exit_status" -eq 0 ]; then

--- a/script-utils.sh
+++ b/script-utils.sh
@@ -49,3 +49,19 @@ run_in_kmake_image() {
     -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
     kmake-image "$cmd" "$@"
 }
+
+run_in_kmake_image_with_passwd() {
+  local cmd="$1"
+  shift
+
+  rm -rf /tmp/passwd.b4
+  echo "user:x:$(id -u):$(id -g):User:$PWD:/bin/bash" > /tmp/passwd.b4
+  docker run -i --rm \
+    --user "$(id -u):$(id -g)" \
+    --workdir="$PWD" \
+    -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
+    -v /tmp/passwd.b4:/etc/passwd:ro \
+    kmake-image "$cmd" "$@"
+
+  rm -rf /tmp/passwd.b4
+}


### PR DESCRIPTION
- Skip patch fetch if Link is missing in commit message
- Ensured b4 is executed within the Docker-based kmake-image environment for consistency