### PR TITLE
check-patch-compliance.sh: Remove quotes from mbox author to fix mism…

### DIFF
--- a/check-patch-compliance.sh
+++ b/check-patch-compliance.sh
@@ -59,7 +59,7 @@ for commit in $commits; do
       fi
 
       # Extract author from mbox downloaded
-      mbox_author=$(grep -m 1 '^From:' out/*.mbx | sed 's/^From:[[:space:]]*//')
+      mbox_author=$(grep -m 1 '^From:' out/*.mbx | sed 's/^From:[[:space:]]*//' | sed 's/"//g')
 
       # Extract the author from local commit
       git_author=$(git show -s --format='%an <%ae>' $commit)


### PR DESCRIPTION
…atch

Fix author mismatch caused by git send-email adding quotes around names with special characters. Strip double quotes from mbox author line to ensure consistent comparison with commit metadata.