### PR TITLE
dtb-check: Drop set -euo pipefail

### DIFF
--- a/dtb-check.sh
+++ b/dtb-check.sh
@@ -7,7 +7,6 @@
 # ./dtb-check.sh --kernel-src <KERNEL_SRC_PATH> --base <BASE_SHA> --head <HEAD_SHA>
 
 set -x
-set -euo pipefail
 
 # Load shared utilities
 source "$(dirname "$0")/script-utils.sh"


### PR DESCRIPTION
Removed strict error handling to allow more flexible script execution. This change prevents the script from exiting on unset variables or command failures, which can be useful during debugging or partial runs.