### PR TITLE
ci: sync: fix base_sha capture for topic repo path

### DIFF
--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -106,10 +106,6 @@ runs:
           git checkout qcom-next
           git reset --hard origin/qcom-next
 
-          # base sha = tip before applying PR
-          base_sha=$(git rev-parse --verify HEAD)
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
-
           cd ..
           if [ ! -d "automerge" ]; then
             git clone https://github.com/qualcomm-linux/automerge.git automerge || {
@@ -132,6 +128,10 @@ runs:
             echo "automerge returned non-zero; check logs for conflicts" >&2
             exit 1
           }
+
+          # base sha = after automerge (all topics integrated), before the PR commits
+          base_sha=$(git rev-parse --verify HEAD)
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
           if [ -n "$PR" ]; then
             REMOTE="https://github.com/${TOPIC_REPO}.git"


### PR DESCRIPTION
In the topic repo path, base_sha was captured immediately after resetting to the qcom-next tip, before ci-merge ran. This caused base_sha..head_sha to span all commits merged in by automerge from every topic branch, plus the PR commits, instead of isolating only the commits introduced by the PR under review.

Capture base_sha after ci-merge completes but before merge_pr() is called, so the range passed to each checker script covers exactly the PR's own commits.